### PR TITLE
Set onestep correctly for rapidez 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.1",
-        "rapidez/core": "^3.0"
+        "rapidez/core": "^4.0"
     },
     "require-dev": {
         "larastan/larastan": "^2.9",

--- a/src/Http/Middleware/SetDemoConfig.php
+++ b/src/Http/Middleware/SetDemoConfig.php
@@ -13,9 +13,9 @@ class SetDemoConfig
 
         if ($request->has('checkout')) {
             if ($request->get('checkout') === 'onestep') {
-                Arr::set($sessionConfig, 'rapidez.frontend.checkout_steps.default', ['onestep']);
+                Arr::set($sessionConfig, 'rapidez.frontend.checkout_steps', ['onestep']);
             } else {
-                Arr::forget($sessionConfig, 'rapidez.frontend.checkout_steps.default');
+                Arr::forget($sessionConfig, 'rapidez.frontend.checkout_steps');
             }
             $request->session()->put('config', $sessionConfig);
         }


### PR DESCRIPTION
With the config refactor, the store-specific value is no longer stored the same way.